### PR TITLE
Network attached to graphical item

### DIFF
--- a/Optimization_Interface/Optimization_Interface.pro
+++ b/Optimization_Interface/Optimization_Interface.pro
@@ -54,6 +54,7 @@ SOURCES += \
     src/graphics/plane_resize_handle.cpp \
     src/graphics/waypoint_graphics_item.cpp \
     src/main.cpp \
+    src/network/waypoint_socket.cpp \
     src/window/main_window.cpp \
     src/graphics/canvas.cpp \
     src/graphics/view.cpp \
@@ -80,6 +81,7 @@ HEADERS += \
     include/controls/compute_thread.h \
     include/graphics/plane_resize_handle.h \
     include/graphics/waypoint_graphics_item.h \
+    include/network/waypoint_socket.h \
     include/window/main_window.h \
     include/graphics/canvas.h \
     include/graphics/view.h \

--- a/Optimization_Interface/include/controls/controller.h
+++ b/Optimization_Interface/include/controls/controller.h
@@ -18,6 +18,7 @@
 #include "include/window/port_dialog.h"
 #include "include/network/drone_socket.h"
 #include "include/network/ellipse_socket.h"
+#include "include/network/waypoint_socket.h"
 #include "include/network/point_socket.h"
 #include "include/controls/compute_thread.h"
 
@@ -93,7 +94,7 @@ class Controller : public QObject {
     PortDialog *port_dialog_;
     DroneSocket *drone_socket_;
     QVector<PointSocket *> final_point_sockets_;
-    QVector<PointSocket *> waypoint_sockets_;
+    QVector<WaypointSocket *> waypoint_sockets_;
     QVector<EllipseSocket *> ellipse_sockets_;
 
     void removeEllipseSocket(EllipseModelItem *model);

--- a/Optimization_Interface/include/graphics/canvas.h
+++ b/Optimization_Interface/include/graphics/canvas.h
@@ -28,7 +28,6 @@ class Canvas : public QGraphicsScene {
     explicit Canvas(QObject *parent = nullptr, QString background_file = "");
     ~Canvas();
     void bringToFront(QGraphicsItem *item);
-    void expandScene();
     QPointF* getBottomLeft();
     QPointF* getTopRight();
     bool indoor_ = true;

--- a/Optimization_Interface/include/graphics/drone_graphics_item.h
+++ b/Optimization_Interface/include/graphics/drone_graphics_item.h
@@ -24,7 +24,6 @@ class DroneGraphicsItem : public QGraphicsItem {
     QRectF boundingRect() const override;
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
               QWidget *widget = nullptr) override;
-    void expandScene();
 
     DroneModelItem *model_;
 

--- a/Optimization_Interface/include/graphics/ellipse_graphics_item.h
+++ b/Optimization_Interface/include/graphics/ellipse_graphics_item.h
@@ -31,7 +31,6 @@ class EllipseGraphicsItem : public QGraphicsItem {
     int type() const override;
 
     void flipDirection();
-    void expandScene();
     void setRed(bool isOverlap);
 
  protected:

--- a/Optimization_Interface/include/graphics/ellipse_resize_handle.h
+++ b/Optimization_Interface/include/graphics/ellipse_resize_handle.h
@@ -31,7 +31,6 @@ class EllipseResizeHandle : public QGraphicsEllipseItem {
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
 
  private:
-    void expandScene();
     EllipseModelItem *model_;
     bool resize_;
     qreal size_;

--- a/Optimization_Interface/include/graphics/path_graphics_item.h
+++ b/Optimization_Interface/include/graphics/path_graphics_item.h
@@ -24,7 +24,6 @@ class PathGraphicsItem : public QGraphicsItem {
     QRectF boundingRect() const override;
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
                QWidget *widget = nullptr) override;
-    void expandScene();
     void setColor(QColor);
 
  protected:

--- a/Optimization_Interface/include/graphics/plane_graphics_item.h
+++ b/Optimization_Interface/include/graphics/plane_graphics_item.h
@@ -30,7 +30,6 @@ class PlaneGraphicsItem : public QGraphicsItem {
                QWidget *widget = nullptr) override;
     int type() const override;
 
-    void expandScene();
     void flipDirection();
 
  protected:

--- a/Optimization_Interface/include/graphics/plane_resize_handle.h
+++ b/Optimization_Interface/include/graphics/plane_resize_handle.h
@@ -35,7 +35,6 @@ class PlaneResizeHandle : public QGraphicsEllipseItem {
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
 
  private:
-    void expandScene();
     PlaneModelItem *model_;
     bool isP2_;
     bool resize_;

--- a/Optimization_Interface/include/graphics/point_graphics_item.h
+++ b/Optimization_Interface/include/graphics/point_graphics_item.h
@@ -26,7 +26,6 @@ class PointGraphicsItem : public QGraphicsItem {
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
                QWidget *widget = nullptr) override;
     int type() const override;
-    void expandScene();
 
  protected:
     QPainterPath shape() const override;

--- a/Optimization_Interface/include/graphics/polygon_graphics_item.h
+++ b/Optimization_Interface/include/graphics/polygon_graphics_item.h
@@ -30,7 +30,6 @@ class PolygonGraphicsItem : public QGraphicsItem {
                QWidget *widget = 0) override;
     int type() const override;
 
-    void expandScene();
     void flipDirection();
 
  protected:

--- a/Optimization_Interface/include/graphics/polygon_resize_handle.h
+++ b/Optimization_Interface/include/graphics/polygon_resize_handle.h
@@ -35,7 +35,6 @@ class PolygonResizeHandle : public QGraphicsEllipseItem {
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
 
  private:
-    void expandScene();
     PolygonModelItem *model_;
     quint32 index_;
     bool resize_;

--- a/Optimization_Interface/include/graphics/waypoint_graphics_item.h
+++ b/Optimization_Interface/include/graphics/waypoint_graphics_item.h
@@ -27,7 +27,6 @@ class WaypointGraphicsItem : public QGraphicsItem {
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
                QWidget *widget = nullptr) override;
     int type() const override;
-    void expandScene();
     void setIndex(quint32 index);
 
  protected:

--- a/Optimization_Interface/include/network/drone_socket.h
+++ b/Optimization_Interface/include/network/drone_socket.h
@@ -12,7 +12,7 @@
 
 #include "autogen/lib.h"
 
-#include "include/models/drone_model_item.h"
+#include "include/graphics/drone_graphics_item.h"
 
 namespace optgui {
 
@@ -20,9 +20,9 @@ class DroneSocket : public QUdpSocket {
     Q_OBJECT
 
  public:
-    explicit DroneSocket(DroneModelItem *model, QObject *parent = nullptr);
+    explicit DroneSocket(DroneGraphicsItem *item, QObject *parent = nullptr);
     ~DroneSocket();
-    DroneModelItem *drone_model_;
+    DroneGraphicsItem *drone_item_;
 
  private slots:
     void readPendingDatagrams();

--- a/Optimization_Interface/include/network/ellipse_socket.h
+++ b/Optimization_Interface/include/network/ellipse_socket.h
@@ -13,7 +13,7 @@
 
 #include "autogen/lib.h"
 
-#include "include/models/ellipse_model_item.h"
+#include "include/graphics/ellipse_graphics_item.h"
 
 namespace optgui {
 
@@ -21,9 +21,10 @@ class EllipseSocket : public QUdpSocket {
     Q_OBJECT
 
  public:
-    explicit EllipseSocket(EllipseModelItem *model, QObject *parent = nullptr);
+    explicit EllipseSocket(EllipseGraphicsItem *item,
+                           QObject *parent = nullptr);
     ~EllipseSocket();
-    EllipseModelItem *ellipse_model_;
+    EllipseGraphicsItem *ellipse_item_;
 
  signals:
     void refresh_graphics();

--- a/Optimization_Interface/include/network/point_socket.h
+++ b/Optimization_Interface/include/network/point_socket.h
@@ -13,7 +13,7 @@
 
 #include "autogen/lib.h"
 
-#include "include/models/point_model_item.h"
+#include "include/graphics/point_graphics_item.h"
 
 namespace optgui {
 
@@ -21,9 +21,10 @@ class PointSocket : public QUdpSocket {
     Q_OBJECT
 
  public:
-    explicit PointSocket(PointModelItem *model, QObject *parent = nullptr);
+    explicit PointSocket(PointGraphicsItem *item,
+                         QObject *parent = nullptr);
     ~PointSocket();
-    PointModelItem *point_model_;
+    PointGraphicsItem *point_item_;
 
  signals:
     void refresh_graphics();

--- a/Optimization_Interface/include/network/waypoint_socket.h
+++ b/Optimization_Interface/include/network/waypoint_socket.h
@@ -1,0 +1,39 @@
+// TITLE:   Optimization_Interface/include/network/waypoint_socket.h
+// AUTHORS: Daniel Sullivan, Miki Szmuk
+// LAB:     Autonomous Controls Lab (ACL)
+// LICENSE: Copyright 2018, All Rights Reserved
+
+// UDP Socket for interacting with point
+// constraint model over network
+
+#ifndef WAYPOINT_SOCKET_H_
+#define WAYPOINT_SOCKET_H_
+
+#include <QUdpSocket>
+
+#include "autogen/lib.h"
+
+#include "include/graphics/waypoint_graphics_item.h"
+
+namespace optgui {
+
+class WaypointSocket : public QUdpSocket {
+    Q_OBJECT
+
+ public:
+    explicit WaypointSocket(WaypointGraphicsItem *item,
+                            QObject *parent = nullptr);
+    ~WaypointSocket();
+    WaypointGraphicsItem *waypoint_item_;
+
+ signals:
+    void refresh_graphics();
+
+ private slots:
+    void readPendingDatagrams();
+};
+
+}  // namespace optgui
+
+#endif  // WAYPOINT_SOCKET_H_
+

--- a/Optimization_Interface/src/controls/controller.cpp
+++ b/Optimization_Interface/src/controls/controller.cpp
@@ -277,23 +277,26 @@ void Controller::freeze_traj() {
 void Controller::setStagedPath() {
     this->model_->stageTraj();
     this->canvas_->path_staged_graphic_->setColor(GREEN);
-    this->canvas_->path_staged_graphic_->expandScene();
+    this->canvas_->path_staged_graphic_->update(
+                this->canvas_->path_staged_graphic_->boundingRect());
 }
 
 void Controller::unsetStagedPath() {
     this->model_->unstageTraj();
-    this->canvas_->path_staged_graphic_->expandScene();
+    this->canvas_->path_staged_graphic_->update(
+                this->canvas_->path_staged_graphic_->boundingRect());
 }
 
 void Controller::tickLiveReference() {
-    this->canvas_->path_staged_graphic_->expandScene();
-
     if (this->model_->tickPathStaged()) {
         autogen::packet::traj3dof traj = this->model_->getStagedTraj3dof();
         if (this->is_simulated_) {
-            this->canvas_->drone_graphic_->model_->
-                    setPos(nedToGuiXyz(traj.pos_ned(0, this->traj_index_),
-                                       traj.pos_ned(1, this->traj_index_)));
+            QPointF coords = nedToGuiXyz(traj.pos_ned(0, this->traj_index_),
+                                         traj.pos_ned(1, this->traj_index_));
+            // set model pos
+            this->canvas_->drone_graphic_->model_->setPos(coords);
+            // set graphic pos so view knows to draw offscreen
+            this->canvas_->drone_graphic_->setPos(coords);
         }
         this->canvas_->drone_graphic_->model_->
                 setVel(nedToGuiXyz(traj.vel_ned(0, this->traj_index_),
@@ -302,13 +305,14 @@ void Controller::tickLiveReference() {
                 setAccel(nedToGuiXyz(traj.accl_ned(0, this->traj_index_),
                                      traj.accl_ned(1, this->traj_index_)));
         this->traj_index_++;
-
-        this->canvas_->drone_graphic_->expandScene();
     } else {
         this->freeze_traj_timer_->stop();
         this->model_->setLiveReferenceMode(false);
         this->unsetStagedPath();
     }
+
+    this->canvas_->path_staged_graphic_->update(
+                this->canvas_->path_staged_graphic_->boundingRect());
 }
 
 void Controller::execute() {
@@ -356,7 +360,7 @@ void Controller::startSockets() {
     // create drone socket
     if (this->canvas_->drone_graphic_->model_->port_ > 0) {
         this->drone_socket_ = new DroneSocket(
-                    this->canvas_->drone_graphic_->model_);
+                    this->canvas_->drone_graphic_);
         connect(this,
                 SIGNAL(trajectoryExecuted(const autogen::packet::traj3dof)),
                 this->drone_socket_,
@@ -368,7 +372,7 @@ void Controller::startSockets() {
     // create final pos sockets
     for (PointGraphicsItem *graphic : this->canvas_->final_points_) {
         if (graphic->model_->port_ > 0) {
-            PointSocket *temp = new PointSocket(graphic->model_);
+            PointSocket *temp = new PointSocket(graphic);
             connect(temp, SIGNAL(refresh_graphics()),
                     this->canvas_, SLOT(update()));
             this->final_point_sockets_.append(temp);
@@ -378,7 +382,7 @@ void Controller::startSockets() {
     // create waypoint sockets
     for (WaypointGraphicsItem *graphic : this->canvas_->waypoint_graphics_) {
         if (graphic->model_->port_ > 0) {
-            PointSocket *temp = new PointSocket(graphic->model_);
+            WaypointSocket *temp = new WaypointSocket(graphic);
             connect(temp, SIGNAL(refresh_graphics()),
                     this->canvas_, SLOT(update()));
             this->waypoint_sockets_.append(temp);
@@ -388,7 +392,7 @@ void Controller::startSockets() {
     // create ellipse sockets
     for (EllipseGraphicsItem *graphic : this->canvas_->ellipse_graphics_) {
         if (graphic->model_->port_ > 0) {
-            EllipseSocket *temp = new EllipseSocket(graphic->model_);
+            EllipseSocket *temp = new EllipseSocket(graphic);
             connect(temp, SIGNAL(refresh_graphics()),
                     this->canvas_, SLOT(updateEllipseGraphicsItem(graphic)));
             this->ellipse_sockets_.append(temp);
@@ -408,7 +412,7 @@ void Controller::closeSockets() {
     this->final_point_sockets_.clear();
 
     // close waypoint sockets
-    for (PointSocket *socket : this->waypoint_sockets_) {
+    for (WaypointSocket *socket : this->waypoint_sockets_) {
         delete socket;
     }
     this->waypoint_sockets_.clear();
@@ -425,7 +429,7 @@ void Controller::removeEllipseSocket(EllipseModelItem *model) {
     bool found = false;
 
     for (EllipseSocket *socket : this->ellipse_sockets_) {
-        if (socket->ellipse_model_ == model) {
+        if (socket->ellipse_item_->model_ == model) {
             delete socket;
             found = true;
             break;
@@ -443,7 +447,7 @@ void Controller::removePointSocket(PointModelItem *model) {
     bool found = false;
 
     for (PointSocket *socket : this->final_point_sockets_) {
-        if (socket->point_model_ == model) {
+        if (socket->point_item_->model_ == model) {
             delete socket;
             found = true;
             break;
@@ -460,8 +464,8 @@ void Controller::removeWaypointSocket(PointModelItem *model) {
     int index = 0;
     bool found = false;
 
-    for (PointSocket *socket : this->waypoint_sockets_) {
-        if (socket->point_model_ == model) {
+    for (WaypointSocket *socket : this->waypoint_sockets_) {
+        if (socket->waypoint_item_->model_ == model) {
             delete socket;
             found = true;
             break;
@@ -484,7 +488,7 @@ void Controller::loadEllipse(EllipseModelItem *item_model) {
     this->model_->addEllipse(item_model);
     item_graphic->setRotation(item_model->getRot());
     this->canvas_->bringToFront(item_graphic);
-    item_graphic->expandScene();
+    item_graphic->update(item_graphic->boundingRect());
 }
 
 void Controller::loadPolygon(PolygonModelItem *item_model) {
@@ -494,7 +498,7 @@ void Controller::loadPolygon(PolygonModelItem *item_model) {
     this->canvas_->polygon_graphics_.insert(item_graphic);
     this->model_->addPolygon(item_model);
     this->canvas_->bringToFront(item_graphic);
-    item_graphic->expandScene();
+    item_graphic->update(item_graphic->boundingRect());
 }
 
 void Controller::loadPlane(PlaneModelItem *item_model) {
@@ -504,7 +508,7 @@ void Controller::loadPlane(PlaneModelItem *item_model) {
     this->canvas_->plane_graphics_.insert(item_graphic);
     this->model_->addPlane(item_model);
     this->canvas_->bringToFront(item_graphic);
-    item_graphic->expandScene();
+    item_graphic->update(item_graphic->boundingRect());
 }
 
 void Controller::loadPoint(PointModelItem *item_model) {
@@ -514,7 +518,7 @@ void Controller::loadPoint(PointModelItem *item_model) {
     this->canvas_->final_points_.insert(item_graphic);
     this->model_->addPoint(item_model);
     item_graphic->setZValue(this->final_point_render_level_);
-    item_graphic->expandScene();
+    item_graphic->update(item_graphic->boundingRect());
 }
 
 void Controller::loadWaypoint(PointModelItem *item_model) {
@@ -525,7 +529,7 @@ void Controller::loadWaypoint(PointModelItem *item_model) {
     this->canvas_->waypoint_graphics_.append(item_graphic);
     this->model_->addWaypoint(item_model);
     item_graphic->setZValue(this->waypoints_render_level_);
-    item_graphic->expandScene();
+    item_graphic->update(item_graphic->boundingRect());
 }
 
 }  // namespace optgui

--- a/Optimization_Interface/src/graphics/canvas.cpp
+++ b/Optimization_Interface/src/graphics/canvas.cpp
@@ -109,13 +109,11 @@ void Canvas::bringSelectedToFront() {
 }
 
 void Canvas::updateEllipseGraphicsItem(EllipseGraphicsItem *graphic) {
-    // TODO(dtsull16): Also try paint, prepareGeometryChange, and update
-    graphic->expandScene();
+    graphic->update(graphic->boundingRect());
 }
 
 void Canvas::updatePathGraphicsItem() {
-    // TODO(dtsull16): Also try paint, prepareGeometryChange, and update
-    this->path_graphic_->expandScene();
+    this->path_graphic_->update(this->path_graphic_->boundingRect());
 }
 
 void Canvas::bringToFront(QGraphicsItem *item) {
@@ -125,21 +123,6 @@ void Canvas::bringToFront(QGraphicsItem *item) {
         item->setZValue(this->front_depth_);
         this->front_depth_ = std::nextafter(this->front_depth_,
                                             std::numeric_limits<qreal>::max());
-    }
-}
-
-void Canvas::expandScene() {
-    for (QGraphicsItem *item : this->items()) {
-        QRectF newRect = item->sceneBoundingRect();
-        QRectF rect = this->sceneRect();
-        if (!rect.contains(newRect)) {
-            this->setSceneRect(this->sceneRect().united(newRect));
-            if (!this->views().isEmpty()) {
-                this->views().first()->setSceneRect(
-                            this->sceneRect());
-            }
-            this->update();
-        }
     }
 }
 

--- a/Optimization_Interface/src/graphics/drone_graphics_item.cpp
+++ b/Optimization_Interface/src/graphics/drone_graphics_item.cpp
@@ -71,23 +71,6 @@ void DroneGraphicsItem::paint(QPainter *painter,
     }
 }
 
-void DroneGraphicsItem::expandScene() {
-    if (scene()) {
-        // expand scene if item goes out of bounds
-        QRectF newRect = this->sceneBoundingRect();
-        QRectF rect = this->scene()->sceneRect();
-        if (!rect.contains(newRect)) {
-            this->scene()->setSceneRect(
-                        this->scene()->sceneRect().united(newRect));
-            if (!this->scene()->views().isEmpty()) {
-                this->scene()->views().first()->setSceneRect(
-                            this->scene()->sceneRect());
-            }
-        }
-        this->update(this->boundingRect());
-    }
-}
-
 QPainterPath DroneGraphicsItem::shape() const {
     QPainterPath path;
     QPolygonF poly;
@@ -105,7 +88,7 @@ QVariant DroneGraphicsItem::itemChange(GraphicsItemChange change,
                                         const QVariant &value) {
     if (change == ItemScenePositionHasChanged && scene()) {
         // check to expand the scene
-        this->expandScene();
+        this->update(this->boundingRect());
     }
     return QGraphicsItem::itemChange(change, value);
 }

--- a/Optimization_Interface/src/graphics/ellipse_graphics_item.cpp
+++ b/Optimization_Interface/src/graphics/ellipse_graphics_item.cpp
@@ -156,23 +156,6 @@ QPainterPath EllipseGraphicsItem::shape() const {
     return path;
 }
 
-void EllipseGraphicsItem::expandScene() {
-    if (this->scene()) {
-        // expand scene if item goes out of bounds
-        QRectF newRect = this->sceneBoundingRect();
-        QRectF rect = this->scene()->sceneRect();
-        if (!rect.contains(newRect)) {
-            this->scene()->setSceneRect(scene()->sceneRect().united(newRect));
-
-            if (!this->scene()->views().isEmpty()) {
-                this->scene()->views().first()->setSceneRect(
-                            this->scene()->sceneRect());
-            }
-        }
-        this->update(this->boundingRect());
-    }
-}
-
 void EllipseGraphicsItem::setRed(bool isOverlap) {
     if (isOverlap) {
         QColor fill = Qt::red;
@@ -187,7 +170,7 @@ void EllipseGraphicsItem::setRed(bool isOverlap) {
 
 void EllipseGraphicsItem::flipDirection() {
     this->model_->flipDirection();
-    this->expandScene();
+    this->update(this->boundingRect());
 }
 
 QVariant EllipseGraphicsItem::itemChange(GraphicsItemChange change,
@@ -200,7 +183,7 @@ QVariant EllipseGraphicsItem::itemChange(GraphicsItemChange change,
         this->model_->setPos(newPos);
 
         // check to expand the scene
-        this->expandScene();
+        this->update(this->boundingRect());
     }
     return QGraphicsItem::itemChange(change, value);
 }

--- a/Optimization_Interface/src/graphics/ellipse_resize_handle.cpp
+++ b/Optimization_Interface/src/graphics/ellipse_resize_handle.cpp
@@ -66,7 +66,7 @@ void EllipseResizeHandle::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
         this->model_->setRot(rotation);
         this->parentItem()->setRotation(rotation);
 
-        this->expandScene();
+        this->update(this->boundingRect());
     }
 }
 
@@ -83,23 +83,6 @@ void EllipseResizeHandle::paint(QPainter *painter,
 
     // paint
     QGraphicsEllipseItem::paint(painter, option, widget);
-}
-
-void EllipseResizeHandle::expandScene() {
-    if (scene()) {
-        // expand scene if item goes out of bounds
-        QRectF newRect = parentItem()->sceneBoundingRect();
-        QRectF rect = this->scene()->sceneRect();
-        if (!rect.contains(newRect)) {
-            this->scene()->setSceneRect(scene()->sceneRect().united(newRect));
-
-            if (!this->scene()->views().isEmpty()) {
-                this->scene()->views().first()->setSceneRect(
-                            this->scene()->sceneRect());
-            }
-        }
-        this->update(this->boundingRect());
-    }
 }
 
 int EllipseResizeHandle::type() const {

--- a/Optimization_Interface/src/graphics/path_graphics_item.cpp
+++ b/Optimization_Interface/src/graphics/path_graphics_item.cpp
@@ -55,23 +55,6 @@ void PathGraphicsItem::paint(QPainter *painter,
     }
 }
 
-void PathGraphicsItem::expandScene() {
-    if (scene()) {
-        // expand scene if item goes out of bounds
-        QRectF newRect = this->sceneBoundingRect();
-        QRectF rect = this->scene()->sceneRect();
-        if (!rect.contains(newRect)) {
-            this->scene()->setSceneRect(
-                        this->scene()->sceneRect().united(newRect));
-            if (!this->scene()->views().isEmpty()) {
-                this->scene()->views().first()->setSceneRect(
-                            this->scene()->sceneRect());
-            }
-        }
-        this->update(this->boundingRect());
-    }
-}
-
 QPainterPath PathGraphicsItem::shape() const {
     QPainterPath path;
     QPolygonF poly;
@@ -86,8 +69,8 @@ QPainterPath PathGraphicsItem::shape() const {
 QVariant PathGraphicsItem::itemChange(GraphicsItemChange change,
                                         const QVariant &value) {
     if (change == ItemScenePositionHasChanged && scene()) {
-        // check to expand the scene
-        this->expandScene();
+        // check redraw
+        this->update(this->boundingRect());
     }
     return QGraphicsItem::itemChange(change, value);
 }

--- a/Optimization_Interface/src/graphics/plane_graphics_item.cpp
+++ b/Optimization_Interface/src/graphics/plane_graphics_item.cpp
@@ -129,26 +129,9 @@ QPainterPath PlaneGraphicsItem::shape() const {
     return path;
 }
 
-void PlaneGraphicsItem::expandScene() {
-    if (scene()) {
-        // expand scene if item goes out of bounds
-        QRectF newRect = this->sceneBoundingRect();
-        QRectF rect = this->scene()->sceneRect();
-        if (!rect.contains(newRect)) {
-            this->scene()->setSceneRect(scene()->sceneRect().united(newRect));
-
-            if (!this->scene()->views().isEmpty()) {
-                this->scene()->views().first()->setSceneRect(
-                            this->scene()->sceneRect());
-            }
-        }
-        this->update(this->boundingRect());
-    }
-}
-
 void PlaneGraphicsItem::flipDirection() {
     this->model_->flipDirection();
-    this->expandScene();
+    this->update(this->boundingRect());
 }
 
 QVariant PlaneGraphicsItem::itemChange(GraphicsItemChange change,
@@ -162,8 +145,8 @@ QVariant PlaneGraphicsItem::itemChange(GraphicsItemChange change,
         this->p1_handle_->updateModel(diff);
         this->p2_handle_->updateModel(diff);
 
-        // check to expand the scene
-        this->expandScene();
+        // check to redraw
+        this->update(this->boundingRect());
     }
     return QGraphicsItem::itemChange(change, value);
 }

--- a/Optimization_Interface/src/graphics/plane_resize_handle.cpp
+++ b/Optimization_Interface/src/graphics/plane_resize_handle.cpp
@@ -93,7 +93,7 @@ void PlaneResizeHandle::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
         } else {
             this->model_->setP1(eventPos);
         }
-        this->expandScene();
+        this->update(this->boundingRect());
     }
 }
 
@@ -106,22 +106,6 @@ QPointF PlaneResizeHandle::getPoint() {
         return this->model_->getP2();
     } else {
         return this->model_->getP1();
-    }
-}
-
-void PlaneResizeHandle::expandScene() {
-    if (scene()) {
-        // expand scene if item goes out of bounds
-        QRectF newRect = this->parentItem()->sceneBoundingRect();
-        QRectF rect = this->scene()->sceneRect();
-        if (!rect.contains(newRect)) {
-            this->scene()->setSceneRect(scene()->sceneRect().united(newRect));
-            if (!this->scene()->views().isEmpty()) {
-                this->scene()->views().first()->setSceneRect(
-                            this->scene()->sceneRect());
-            }
-        }
-        this->update(this->boundingRect());
     }
 }
 

--- a/Optimization_Interface/src/graphics/point_graphics_item.cpp
+++ b/Optimization_Interface/src/graphics/point_graphics_item.cpp
@@ -97,23 +97,6 @@ QPainterPath PointGraphicsItem::shape() const {
     return path;
 }
 
-void PointGraphicsItem::expandScene() {
-    if (scene()) {
-        // expand scene if item goes out of bounds
-        QRectF newRect = this->sceneBoundingRect();
-        QRectF rect = this->scene()->sceneRect();
-        if (!rect.contains(newRect)) {
-            this->scene()->setSceneRect(scene()->sceneRect().united(newRect));
-
-            if (!this->scene()->views().isEmpty()) {
-                this->scene()->views().first()->setSceneRect(
-                            this->scene()->sceneRect());
-            }
-        }
-        this->update(this->boundingRect());
-    }
-}
-
 QVariant PointGraphicsItem::itemChange(GraphicsItemChange change,
                                        const QVariant &value) {
     if (change == ItemPositionChange && scene()) {
@@ -123,8 +106,8 @@ QVariant PointGraphicsItem::itemChange(GraphicsItemChange change,
         // update model
         this->model_->setPos(newPos);
 
-        // check to expand the scene
-        this->expandScene();
+        // check to redraw
+        this->update(this->boundingRect());
     }
     return QGraphicsItem::itemChange(change, value);
 }

--- a/Optimization_Interface/src/graphics/polygon_graphics_item.cpp
+++ b/Optimization_Interface/src/graphics/polygon_graphics_item.cpp
@@ -159,26 +159,9 @@ QPainterPath PolygonGraphicsItem::shape() const {
     return path;
 }
 
-void PolygonGraphicsItem::expandScene() {
-    if (scene()) {
-        // expand scene if item goes out of bounds
-        QRectF newRect = this->sceneBoundingRect();
-        QRectF rect = this->scene()->sceneRect();
-        if (!rect.contains(newRect)) {
-            this->scene()->setSceneRect(
-                        this->scene()->sceneRect().united(newRect));
-            if (!this->scene()->views().isEmpty()) {
-                this->scene()->views().first()->setSceneRect(
-                            this->scene()->sceneRect());
-            }
-        }
-        this->update(this->boundingRect());
-    }
-}
-
 void PolygonGraphicsItem::flipDirection() {
     this->model_->flipDirection();
-    this->expandScene();
+    this->update(this->boundingRect());
 }
 
 QVariant PolygonGraphicsItem::itemChange(GraphicsItemChange change,
@@ -194,7 +177,7 @@ QVariant PolygonGraphicsItem::itemChange(GraphicsItemChange change,
         }
 
         // check to expand the scene
-        this->expandScene();
+        this->update(this->boundingRect());
     }
     return QGraphicsItem::itemChange(change, value);
 }

--- a/Optimization_Interface/src/graphics/polygon_resize_handle.cpp
+++ b/Optimization_Interface/src/graphics/polygon_resize_handle.cpp
@@ -79,7 +79,7 @@ void PolygonResizeHandle::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
     if (this->resize_) {
         QPointF eventPos = event->scenePos();
         this->model_->setPointAt(eventPos, this->index_);
-        this->expandScene();
+        this->update(this->boundingRect());
     }
 }
 
@@ -89,22 +89,6 @@ int PolygonResizeHandle::type() const {
 
 QPointF PolygonResizeHandle::getPoint() {
     return this->model_->getPointAt(this->index_);
-}
-
-void PolygonResizeHandle::expandScene() {
-    if (scene()) {
-        // expand scene if item goes out of bounds
-        QRectF newRect = this->parentItem()->sceneBoundingRect();
-        QRectF rect = this->scene()->sceneRect();
-        if (!rect.contains(newRect)) {
-            this->scene()->setSceneRect(scene()->sceneRect().united(newRect));
-            if (!this->scene()->views().isEmpty()) {
-                this->scene()->views().first()->setSceneRect(
-                            this->scene()->sceneRect());
-            }
-        }
-        this->update(this->boundingRect());
-    }
 }
 
 qreal PolygonResizeHandle::getScalingFactor() const {

--- a/Optimization_Interface/src/graphics/waypoint_graphics_item.cpp
+++ b/Optimization_Interface/src/graphics/waypoint_graphics_item.cpp
@@ -103,23 +103,6 @@ int WaypointGraphicsItem::type() const {
     return WAYPOINT_GRAPHIC;
 }
 
-void WaypointGraphicsItem::expandScene() {
-    if (scene()) {
-        // expand scene if item goes out of bounds
-        QRectF newRect = this->sceneBoundingRect();
-        QRectF rect = this->scene()->sceneRect();
-        if (!rect.contains(newRect)) {
-            this->scene()->setSceneRect(scene()->sceneRect().united(newRect));
-
-            if (!this->scene()->views().isEmpty()) {
-                this->scene()->views().first()->setSceneRect(
-                            this->scene()->sceneRect());
-            }
-        }
-        this->update(this->boundingRect());
-    }
-}
-
 QVariant WaypointGraphicsItem::itemChange(GraphicsItemChange change,
                                        const QVariant &value) {
     if (change == ItemPositionChange && scene()) {
@@ -129,8 +112,8 @@ QVariant WaypointGraphicsItem::itemChange(GraphicsItemChange change,
         // update model
         this->model_->setPos(newPos);
 
-        // check to expand the scene
-        this->expandScene();
+        // redraw graphic
+        this->update(this->boundingRect());
     }
     return QGraphicsItem::itemChange(change, value);
 }

--- a/Optimization_Interface/src/network/point_socket.cpp
+++ b/Optimization_Interface/src/network/point_socket.cpp
@@ -9,10 +9,10 @@
 
 namespace optgui {
 
-PointSocket::PointSocket(PointModelItem *model, QObject *parent)
+PointSocket::PointSocket(PointGraphicsItem *item, QObject *parent)
     : QUdpSocket(parent) {
-    point_model_ = model;
-    this->bind(QHostAddress::AnyIPv4, point_model_->port_);
+    this->point_item_ = item;
+    this->bind(QHostAddress::AnyIPv4, this->point_item_->model_->port_);
 
     connect(this, SIGNAL(readyRead()), this, SLOT(readPendingDatagrams()));
 }
@@ -38,8 +38,11 @@ void PointSocket::readPendingDatagrams() {
                 QPointF gui_coords =
                         nedToGuiXyz(telemetry_data.pos_ned(0),
                                     telemetry_data.pos_ned(1));
-                this->point_model_->setPos(gui_coords);
-              emit refresh_graphics();
+                // set model coords
+                this->point_item_->model_->setPos(gui_coords);
+                // set graphics coords so view knows to render it
+                this->point_item_->setPos(gui_coords);
+                emit refresh_graphics();
             }
         }
     }

--- a/Optimization_Interface/src/network/waypoint_socket.cpp
+++ b/Optimization_Interface/src/network/waypoint_socket.cpp
@@ -1,27 +1,27 @@
-// TITLE:   Optimization_Interface/src/network/ellipse_socket.cpp
-// AUTHORS: Daniel Sullivan, Miki Szmuk
+// TITLE:   Optimization_Interface/src/network/waypoint_socket.cpp
+// AUTHORS: Daniel Sullivan
 // LAB:     Autonomous Controls Lab (ACL)
-// LICENSE: Copyright 2018, All Rights Reserved
+// LICENSE: Copyright 2020, All Rights Reserved
 
-#include "include/network/ellipse_socket.h"
+#include "include/network/waypoint_socket.h"
 
 #include "include/globals.h"
 
 namespace optgui {
 
-EllipseSocket::EllipseSocket(EllipseGraphicsItem *item, QObject *parent)
+WaypointSocket::WaypointSocket(WaypointGraphicsItem *item, QObject *parent)
     : QUdpSocket(parent) {
-    this->ellipse_item_ = item;
-    this->bind(QHostAddress::AnyIPv4, this->ellipse_item_->model_->port_);
+    this->waypoint_item_ = item;
+    this->bind(QHostAddress::AnyIPv4, this->waypoint_item_->model_->port_);
 
     connect(this, SIGNAL(readyRead()), this, SLOT(readPendingDatagrams()));
 }
 
-EllipseSocket::~EllipseSocket() {
+WaypointSocket::~WaypointSocket() {
     this->close();
 }
 
-void EllipseSocket::readPendingDatagrams() {
+void WaypointSocket::readPendingDatagrams() {
     while (this->hasPendingDatagrams()) {
         char buffer[4000] = {0};
         QHostAddress address;
@@ -38,10 +38,10 @@ void EllipseSocket::readPendingDatagrams() {
                 QPointF gui_coords =
                         nedToGuiXyz(telemetry_data.pos_ned(0),
                                     telemetry_data.pos_ned(1));
-                // set model pos
-                this->ellipse_item_->model_->setPos(gui_coords);
-                // set graphics pos so view knows whether to paint it
-                this->ellipse_item_->setPos(gui_coords);
+                // set model coords
+                this->waypoint_item_->model_->setPos(gui_coords);
+                // set graphics coords so view knows to render it
+                this->waypoint_item_->setPos(gui_coords);
                 emit refresh_graphics();
             }
         }


### PR DESCRIPTION
Notes
- network moves graphical item, not just model item. allows view to
detect when to draw the item
- can remove expand view checks. might improve performance
- no need to continuously expand scene. Size restricted by max zoom out level anyway

Issues
- https://github.com/dtsullivan/optgui/issues/106